### PR TITLE
Feature: Allow existing SNS via a variable flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # .tfvars files
 *.tfvars
+
+# Build harness
+.build-harness
+build-harness/

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ module "es_alarms" {
 | `monitor_master_cpu_utilization_too_high` | Enable monitoring of CPU utilization of master nodes are too high. Only enable this when dedicated master is enabled | string | `false` | no |
 | `monitor_master_jvm_memory_pressure_too_high` | Enable monitoring of JVM memory pressure of master nodes are too high. Only enable this wwhen dedicated master is enabled | string | `false` | no |
 | `create_sns_topic` | Will create an SNS topic, if you set this to false you MUST set `sns_topic` to a FULL ARN | string | `true` | no |
-| `sns_topic` | SNS topic you want to specify. If leave empty, it will use a prefix and a timestampe appended.  If `create_sns_topic` is set to false, this MUST be a FULL ARN | string | `""` | no |
+| `sns_topic` | SNS topic you want to specify. If leave empty, it will use a prefix and a timestamp appended.  If `create_sns_topic` is set to false, this MUST be a FULL ARN | string | `""` | no |
 | `sns_topic_postfix` | SNS topic postfix | string | `""` | no |
 | `sns_topic_prefix` | SNS topic prefix | string | `""` | no |
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ module "es_alarms" {
 }
 ```
 
+You can alternatively have this module not create an SNS incase you have existing ones created elsewhere.
+
+```hcl
+module "es_alarms" {
+  source           = "github::https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.git?ref=master"
+  domain_name      = "example"
+  sns_topic        = "arn:aws:sns:us-east-1:123456123456:sns-to-slack"   # < Put your full SNS ARN here, if necessary read from var or a resource
+  create_sns_topic = false
+}
+```
+
 
 ## Inputs
 
@@ -80,7 +91,8 @@ module "es_alarms" {
 | `monitor_jvm_memory_pressure_too_high` | Enable monitoring of JVM memory pressure is too high | string | `true` | no |
 | `monitor_master_cpu_utilization_too_high` | Enable monitoring of CPU utilization of master nodes are too high. Only enable this when dedicated master is enabled | string | `false` | no |
 | `monitor_master_jvm_memory_pressure_too_high` | Enable monitoring of JVM memory pressure of master nodes are too high. Only enable this wwhen dedicated master is enabled | string | `false` | no |
-| `sns_topic` | SNS topic you want to specify. If leave empty, it will use a prefix and a timestampe appended | string | `""` | no |
+| `create_sns_topic` | Will create an SNS topic, if you set this to false you MUST set `sns_topic` to a FULL ARN | string | `true` | no |
+| `sns_topic` | SNS topic you want to specify. If leave empty, it will use a prefix and a timestampe appended.  If `create_sns_topic` is set to false, this MUST be a FULL ARN | string | `""` | no |
 | `sns_topic_postfix` | SNS topic postfix | string | `""` | no |
 | `sns_topic_prefix` | SNS topic prefix | string | `""` | no |
 

--- a/examples/use-existing-sns/main.tf
+++ b/examples/use-existing-sns/main.tf
@@ -1,0 +1,33 @@
+### For connecting and provisioning
+variable "region" {
+  default = "us-west-2"
+}
+
+provider "aws" {
+  region = var.region
+
+  # Make it faster by skipping something
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+# Create an existing SNS topic (aka, do not create in module)
+resource "aws_sns_topic" "this" {
+  name  = "using-existing-sns-topic-test"
+}
+
+module "es_alarms" {
+  source              = "../../"
+  domain_name         = "example"
+  # To use an existing SNS topic, your sns_topic MUST be a full ARN
+  sns_topic           = var.aws_sns_topic.arn
+  # And you must set this to false
+  create_sns_topic    = false
+}
+
+output "es_alarms_sns_topic_arn" {
+  value = module.es_alarms.sns_topic_arn
+}

--- a/main.tf
+++ b/main.tf
@@ -16,24 +16,24 @@ resource "aws_sns_topic" "default" {
 }
 
 locals {
-  aws_sns_topic_arn  = coalesce(
-      element(
-        concat(
-          aws_sns_topic.default_prefix.*.arn,
-          [""],
-        ),
-        0,
+  aws_sns_topic_arn = coalesce(
+    element(
+      concat(
+        aws_sns_topic.default_prefix.*.arn,
+        [""],
       ),
-      element(
-        concat(
-          aws_sns_topic.default.*.arn,
-          [""],
-        ),
-        0,
+      0,
+    ),
+    element(
+      concat(
+        aws_sns_topic.default.*.arn,
+        [""],
       ),
-      var.sns_topic
-    )
-  aws_sns_topic_name = element(split(":",local.aws_sns_topic_arn),5)
+      0,
+    ),
+    var.sns_topic
+  )
+  aws_sns_topic_name = element(split(":", local.aws_sns_topic_arn), 5)
 }
 
 resource "aws_sns_topic_policy" "default" {
@@ -43,7 +43,7 @@ resource "aws_sns_topic_policy" "default" {
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
-  count  = var.create_sns_topic == true ? 1 : 0
+  count     = var.create_sns_topic == true ? 1 : 0
   policy_id = "__default_policy_ID"
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -6,26 +6,44 @@ data "aws_caller_identity" "default" {}
 
 # Make a topic
 resource "aws_sns_topic" "default_prefix" {
-  count       = var.sns_topic == "" ? 1 : 0
+  count       = var.sns_topic == "" && var.create_sns_topic == true ? 1 : 0
   name_prefix = "${var.sns_topic_prefix}elasticsearch-threshold-alerts${var.sns_topic_postfix}"
 }
 
 resource "aws_sns_topic" "default" {
-  count = var.sns_topic != "" ? 1 : 0
+  count = var.sns_topic != "" && var.create_sns_topic == true ? 1 : 0
   name  = "${var.sns_topic_prefix}${var.sns_topic}${var.sns_topic_postfix}"
 }
 
 locals {
-  aws_sns_topic_arn  = var.sns_topic == "" ? element(concat(aws_sns_topic.default_prefix.*.arn, list("")), 0) : element(concat(aws_sns_topic.default.*.arn, list("")), 0)
-  aws_sns_topic_name = var.sns_topic == "" ? element(concat(aws_sns_topic.default_prefix.*.name, list("")), 0) : var.sns_topic
+  aws_sns_topic_arn  = coalesce(
+      element(
+        concat(
+          aws_sns_topic.default_prefix.*.arn,
+          [""],
+        ),
+        0,
+      ),
+      element(
+        concat(
+          aws_sns_topic.default.*.arn,
+          [""],
+        ),
+        0,
+      ),
+      var.sns_topic
+    )
+  aws_sns_topic_name = element(split(":",local.aws_sns_topic_arn),5)
 }
 
 resource "aws_sns_topic_policy" "default" {
+  count  = var.create_sns_topic == true ? 1 : 0
   arn    = local.aws_sns_topic_arn
-  policy = data.aws_iam_policy_document.sns_topic_policy.json
+  policy = data.aws_iam_policy_document.sns_topic_policy[0].json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
+  count  = var.create_sns_topic == true ? 1 : 0
   policy_id = "__default_policy_ID"
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "domain_name" {
   type        = string
 }
 
+variable "create_sns_topic" {
+  description = "If you don't want to create the SNS topic, set this to false.  It will use the sns_topic value directly"
+  type        = bool
+  default     = true
+}
+
 variable "sns_topic" {
   description = "SNS topic you want to specify. If leave empty, it will use a prefix and a timestampe appended"
   type        = string


### PR DESCRIPTION
If anyone has an existing SNS topic, I allowed this module to use that instead of creating one needlessly.  The topics created by this module would typically have to then be manually setup with destinations to trigger (email, webhooks, etc), so creating them externally makes a lot of sense (arguably more).