### PR TITLE
Update README to indicate that metric AWS/ES FreeStorageSpace is in MiB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ module "es_alarms" {
 | `alarm_name_postfix` | Alarm name postfix | string | `""` | no |
 | `alarm_name_prefix` | Alarm name prefix | string | `""` | no |
 | `cpu_utilization_threshold` | The maximum percentage of CPU utilization | string | `80` | no |
-| `free_storage_space_threshold` | The minimum amount of available storage space in Byte. | string | `21474836480` | no |
+| `free_storage_space_threshold` | The minimum amount of available storage space in MiB. | string | `20480` | no |
 | `jvm_memory_pressure_threshold` | The maximum percentage of the Java heap used for all data nodes in the cluster | string | `80` | no |
 | `master_cpu_utilization_threshold` | The maximum percentage of CPU utilization of master nodes | string | `""` | no |
 | `master_jvm_memory_pressure_threshold` | The maximum percentage of the Java heap used for master nodes in the cluster | string | `""` | no |


### PR DESCRIPTION
This appears to be in MiB, sourcing both the table at the top of the README for reference as well as [Recommended CloudWatch Alarms](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html) in the AWS documentation. 