### PR TITLE
Refactor backend configuration out of main.tf

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {}
-}
-
 data "aws_caller_identity" "default" {}
 
 # Make a topic


### PR DESCRIPTION
Why is it necessary? (Bug fix, feature, improvements?)
- improvement: The backend is tied to AWS S3 and tightly coupled with
  the main implementation.  Moving to its own file allows for
  flexibility to overwrite file if users are not storing their
  configuration in S3 or want some other S3 configuration

How does the change address the issue?
- Move the backend config into its own resource file

What side effects does this change have?
- None