### PR TITLE
Adding tags, KMS Support, Customizing some periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ resource "aws_elasticsearch_domain" "es" {
 module "es_alarms" {
   source         = "github::https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.git?ref=master"
   domain_name    = "example"
+  tags = {
+    Domain = "TestDomain"
+  }
 }
 ```
 
@@ -66,6 +69,9 @@ module "es_alarms" {
   domain_name      = "example"
   sns_topic        = "arn:aws:sns:us-east-1:123456123456:sns-to-slack"   # < Put your full SNS ARN here, if necessary read from var or a resource
   create_sns_topic = false
+  tags = {
+    Domain = "TestDomain"
+  }
 }
 ```
 
@@ -99,6 +105,7 @@ module "es_alarms" {
 | `sns_topic`                                   | SNS topic you want to specify. If leave empty, it will use a prefix and a timestamp appended.  If `create_sns_topic` is set to false, this MUST be a FULL ARN | string | `""` | no |
 | `sns_topic_postfix`                           | SNS topic postfix | string | `""` | no |
 | `sns_topic_prefix`                            | SNS topic prefix | string | `""` | no |
+| `tags`                                        | Tags to associate with all created resources | map | `{}` | no |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 [![Build Status](https://travis-ci.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.svg?branch=master)](https://travis-ci.org/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms)
 [![Latest Release](https://img.shields.io/github/release/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms.svg)](https://github.com/dubiety/terraform-aws-elasticsearch-cloudwatch-sns-alarms/releases)
 
-Terraform module that configures important elasticsearch alerts using CloudWatch and sends them to an SNS topic.
-
-Create a set of sane Elasticsearch CloudWatch alerts for monitoring the health of an elasticsearch cluster.
+Terraform module that configures the [recommended Amazon ElasticSearch Alarms](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html) using CloudWatch and sends alerts to an SNS topic.  By default, this module creates an SNS topic, but it can be configured to point to an existing SNS topic (see [example](./examples/use-existing-sns/main.tf))
 
 `v1.x` supports terraform `v0.12` syntax!
 
@@ -13,20 +11,24 @@ This project is inspired by [CloudPosse](https://github.com/cloudposse)
 
 It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
-## Usage
+## Metrics and Alarms
 
-| area       | metric                    | comparison operator | threshold | rationale                                                                                                                                                                                                      |
-|------------|---------------------------|---------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Sharding   | ClusterStatus.red         | `>=`                | 1         | At least one primary shard and its replicas are not allocated to a node for 1 minute 1 consecutive time. Threshold should always be 1.                                                                         |
-| Sharding   | ClusterStatus.yellow      | `>=`                | 1         | At least one replica shard is not allocated to a node for 1 minute 1 consecutive time. Threshold should always be 1.                                                                                           |
-| Storage    | FreeStorageSpace          | `<=`                | 20480 MB  | A node in your cluster is down to 20 GiB of free storage space for 1 minute 1 consecutive time. This value is in MiB, so rather than 20480, we recommend setting it to 25% of the storage space for each node. |
-| Storage    | ClusterIndexWritesBlocked | `>=`                | 1         | The cluster is blocking write requests for 5 minutes 1 consecutive time. Threshold should always be 1.                                                                                                         |
-| Node Count | Nodes                     | `<`                 | `x`       | `x` is the number of nodes in your cluster. This alarm indicates that at least one node in your cluster has been unreachable for one day.                                                                      |
-| Snapshot   | AutomatedSnapshotFailure  | `>=`                | 1         | An automated snapshot failed for 1 minute 1 consecutive time. This failure is often the result of a red cluster health status.                                                                                 |
-| CPU        | CPUUtilization            | `>=`                | 80 %      | CPU utilization average is >= 80% for 15 minutes, 3 consecutive times for the node cluster.                                                                                                                    |
-| Memory     | JVMMemoryPressure         | `>=`                | 80 %      | JVMMemoryPressure maximum is >= 80% for 15 minutes, 1 consecutive time.                                                                                                                                        |
-| CPU        | MasterCPUUtilization      | `>=`                | 80 %      | Dedicated master nodes' CPU utilization is >= 80% for 15 minutes, 3 consecutive times.                                                                                                                         |
-| Memory     | MasterJVMMemoryPressure   | `>=`                | 80 %      | Dedicated master nodes' maximum JVM memory usage is >= 80% for 15 minutes, 1 consecutive time.                                                                                                                 |
+| area       | metric                    | operator | threshold | rationale                                                                                                                              |
+|------------|---------------------------|----------|-----------|----------------------------------------------------------------------------------------------------------------------------------------|
+| Sharding   | ClusterStatus.red         | `>=`     | 1         | At least one primary shard and its replicas are not allocated to a node                                                                |
+| Sharding   | ClusterStatus.yellow      | `>=`     | 1         | At least one replica shard is not allocated to a node                                                                                  |
+| Storage    | FreeStorageSpace          | `<=`     | 20480 MB  | A node in your cluster is down to low storage space.                                                                                   |
+| Storage    | ClusterIndexWritesBlocked | `>=`     | 1         | Your cluster is blocking write requests.                                                                                               |
+| Node Count | Nodes                     | `<`      | `x`       | This alarm indicates that at least one node in your cluster has been unreachable for one day                                           |
+| Snapshot   | AutomatedSnapshotFailure  | `>=`     | 1         | An automated snapshot failed. This failure is often the result of a red cluster health status.                                         |
+| CPU        | CPUUtilization            | `>=`     | 80 %      | 100% CPU utilization isn't uncommon, but sustained high usage is problematic. Consider using larger instance types or more instances.  |
+| Memory     | JVMMemoryPressure         | `>=`     | 80 %      | The cluster could encounter out of memory errors if usage increases. Consider scaling vertically.                                      |
+| CPU        | MasterCPUUtilization      | `>=`     | 80 %      | Consider using larger instance types for your dedicated master nodes.                                                                  |
+| Memory     | MasterJVMMemoryPressure   | `>=`     | 80 %      | Consider using larger instance types for your dedicated master nodes.                                                                  |
+| KMS        | KMSKeyError               | `>=`     | 1         | The KMS encryption key that is used to encrypt data at rest in your domain is disabled. Re-enable it to restore normal operations      |
+| Memory     | KMSKeyInaccessible        | `>=`     | 80 %      | The KMS encryption key that is used to encrypt data at rest in your domain has been deleted or has revoked its grants to Amazon ES     |
+
+For more information please see: [recommended Amazon ElasticSearch Alarms](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html).
 
 ## Examples
 
@@ -70,31 +72,34 @@ module "es_alarms" {
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| `domain_name` | The Elasticserach domain name you want to monitor. | string | - | yes |
-| `alarm_name_postfix` | Alarm name postfix | string | `""` | no |
-| `alarm_name_prefix` | Alarm name prefix | string | `""` | no |
-| `cpu_utilization_threshold` | The maximum percentage of CPU utilization | string | `80` | no |
-| `free_storage_space_threshold` | The minimum amount of available storage space in Byte. | string | `21474836480` | no |
-| `jvm_memory_pressure_threshold` | The maximum percentage of the Java heap used for all data nodes in the cluster | string | `80` | no |
-| `master_cpu_utilization_threshold` | The maximum percentage of CPU utilization of master nodes | string | `""` | no |
-| `master_jvm_memory_pressure_threshold` | The maximum percentage of the Java heap used for master nodes in the cluster | string | `""` | no |
-| `min_available_nodes` | The minimum available (reachable) nodes to have | string | `1` | no |
-| `monitor_automated_snapshot_failure` | Enable monitoring of automated snapshot failure | string | `true` | no |
-| `monitor_cluster_index_writes_blocked` | Enable monitoring of cluster index writes being blocked | string | `true` | no |
-| `monitor_cluster_status_is_red` | Enable monitoring of cluster status is in red | string | `true` | no |
-| `monitor_cluster_status_is_yellow` | Enable monitoring of cluster status is in yellow | string | `true` | no |
-| `monitor_cpu_utilization_too_high` | Enable monitoring of CPU utilization is too high | string | `true` | no |
-| `monitor_free_storage_space_too_low` | Enable monitoring of cluster average free storage is to low | string | `true` | no |
-| `monitor_insufficient_available_nodes` | Enable monitoring insufficient available nodes | string | `false` | no |
-| `monitor_jvm_memory_pressure_too_high` | Enable monitoring of JVM memory pressure is too high | string | `true` | no |
-| `monitor_master_cpu_utilization_too_high` | Enable monitoring of CPU utilization of master nodes are too high. Only enable this when dedicated master is enabled | string | `false` | no |
-| `monitor_master_jvm_memory_pressure_too_high` | Enable monitoring of JVM memory pressure of master nodes are too high. Only enable this wwhen dedicated master is enabled | string | `false` | no |
-| `create_sns_topic` | Will create an SNS topic, if you set this to false you MUST set `sns_topic` to a FULL ARN | string | `true` | no |
-| `sns_topic` | SNS topic you want to specify. If leave empty, it will use a prefix and a timestamp appended.  If `create_sns_topic` is set to false, this MUST be a FULL ARN | string | `""` | no |
-| `sns_topic_postfix` | SNS topic postfix | string | `""` | no |
-| `sns_topic_prefix` | SNS topic prefix | string | `""` | no |
+| Name                                          | Description | Type | Default | Required |
+|-----------------------------------------------|-------------|:----:|:-------:|:--------:|
+| `domain_name`                                 | The Elasticserach domain name you want to monitor. | string | - | yes |
+| `alarm_cluster_status_is_yellow_periods`      | The number of periods before triggering the cluster status is yellow, raise this if desired to make less noisy | number | `1` | no |
+| `alarm_free_storage_space_too_low_periods`    | The number of periods before triggering the disk space is low, raise this if desired to make less noisy | number | `1` | no |
+| `alarm_name_postfix`                          | Alarm name postfix | string | `""` | no |
+| `alarm_name_prefix`                           | Alarm name prefix | string | `""` | no |
+| `cpu_utilization_threshold`                   | The maximum percentage of CPU utilization | string | `80` | no |
+| `free_storage_space_threshold`                | The minimum amount of available storage space in Byte. | string | `21474836480` | no |
+| `jvm_memory_pressure_threshold`               | The maximum percentage of the Java heap used for all data nodes in the cluster | string | `80` | no |
+| `master_cpu_utilization_threshold`            | The maximum percentage of CPU utilization of master nodes | string | `""` | no |
+| `master_jvm_memory_pressure_threshold`        | The maximum percentage of the Java heap used for master nodes in the cluster | string | `""` | no |
+| `min_available_nodes`                         | The minimum available (reachable) nodes to have, set to non-zero to enable alarm | string | `0` | no |
+| `monitor_automated_snapshot_failure`          | Enable monitoring of automated snapshot failure | bool | `true` | no |
+| `monitor_cluster_index_writes_blocked`        | Enable monitoring of cluster index writes being blocked | bool | `true` | no |
+| `monitor_cluster_status_is_red`               | Enable monitoring of cluster status is in red | bool | `true` | no |
+| `monitor_cluster_status_is_yellow`            | Enable monitoring of cluster status is in yellow | bool | `true` | no |
+| `monitor_cpu_utilization_too_high`            | Enable monitoring of CPU utilization is too high | bool | `true` | no |
+| `monitor_free_storage_space_too_low`          | Enable monitoring of cluster average free storage is to low | bool | `true` | no |
+| `monitor_jvm_memory_pressure_too_high`        | Enable monitoring of JVM memory pressure is too high | bool | `true` | no |
+| `monitor_kms`                                 | Enable monitoring of KMS-related metrics, enable if using KMS | bool | `false` | no |
+| `monitor_master_cpu_utilization_too_high`     | Enable monitoring of CPU utilization of master nodes are too high. Only enable this when dedicated master is enabled | bool | `false` | no |
+| `monitor_master_jvm_memory_pressure_too_high` | Enable monitoring of JVM memory pressure of master nodes are too high. Only enable this wwhen dedicated master is enabled | bool | `false` | no |
+| `create_sns_topic`                            | Will create an SNS topic, if you set this to false you MUST set `sns_topic` to a FULL ARN | bool | `true` | no |
+| `sns_topic`                                   | SNS topic you want to specify. If leave empty, it will use a prefix and a timestamp appended.  If `create_sns_topic` is set to false, this MUST be a FULL ARN | string | `""` | no |
+| `sns_topic_postfix`                           | SNS topic postfix | string | `""` | no |
+| `sns_topic_prefix`                            | SNS topic prefix | string | `""` | no |
+
 
 ## Outputs
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -19,10 +19,11 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_is_red" {
   period              = "60"
   statistic           = "Maximum"
   threshold           = "1"
-  alarm_description   = "Average elasticsearch cluster status is in red over last 1 minutes"
+  alarm_description   = "Average elasticsearch cluster status is in red over last 1 minute"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
   treat_missing_data  = "ignore"
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -34,16 +35,17 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_is_yellow" {
   count               = var.monitor_cluster_status_is_yellow ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterStatusIsYellow${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.alarm_cluster_status_is_yellow_periods
   metric_name         = "ClusterStatus.yellow"
   namespace           = "AWS/ES"
   period              = "60"
   statistic           = "Maximum"
   threshold           = "1"
-  alarm_description   = "Average elasticsearch cluster status is in yellow over last 1 minutes"
+  alarm_description   = "Average elasticsearch cluster status is in yellow over last ${var.alarm_cluster_status_is_yellow_periods} minute(s)"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
   treat_missing_data  = "ignore"
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -55,16 +57,17 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   count               = var.monitor_free_storage_space_too_low ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-FreeStorageSpaceTooLow${var.alarm_name_postfix}"
   comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.alarm_free_storage_space_too_low_periods
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/ES"
   period              = "60"
   statistic           = "Minimum"
   threshold           = local.thresholds["FreeStorageSpaceThreshold"]
-  alarm_description   = "Average elasticsearch free storage space over last 1 minutes is too low"
+  alarm_description   = "Average elasticsearch free storage space over last ${var.alarm_free_storage_space_too_low_periods} minute(s) is too low"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
   treat_missing_data  = "ignore"
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -86,6 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
   treat_missing_data  = "ignore"
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -107,6 +111,7 @@ resource "aws_cloudwatch_metric_alarm" "insufficient_available_nodes" {
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
   treat_missing_data  = "ignore"
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -124,10 +129,11 @@ resource "aws_cloudwatch_metric_alarm" "automated_snapshot_failure" {
   period              = "60"
   statistic           = "Maximum"
   threshold           = "1"
-  alarm_description   = "Elasticsearch automated snapshot failed over last 1 minutes"
+  alarm_description   = "Elasticsearch automated snapshot failed over last 1 minute"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
   treat_missing_data  = "ignore"
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -148,6 +154,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   alarm_description   = "Average elasticsearch cluster CPU utilization over last 45 minutes too high"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -168,6 +175,7 @@ resource "aws_cloudwatch_metric_alarm" "jvm_memory_pressure_too_high" {
   alarm_description   = "Elasticsearch JVM memory pressure is too high over last 15 minutes"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -188,6 +196,7 @@ resource "aws_cloudwatch_metric_alarm" "master_cpu_utilization_too_high" {
   alarm_description   = "Average elasticsearch cluster CPU utilization over last 45 minutes too high"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name
@@ -208,6 +217,51 @@ resource "aws_cloudwatch_metric_alarm" "master_jvm_memory_pressure_too_high" {
   alarm_description   = "Elasticsearch JVM memory pressure is too high over last 15 minutes"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
+  tags                = var.tags
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.default.account_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kms_key_error" {
+  count               = var.monitor_kms ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-KMSKeyError${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "KMSKeyError"
+  namespace           = "AWS/ES"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "Elasticsearch KMS Key Error failed over last 1 minute"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+  tags                = var.tags
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.default.account_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kms_key_inaccessible" {
+  count               = var.monitor_kms ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-KMSKeyInaccessible${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "KMSKeyInaccessible"
+  namespace           = "AWS/ES"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "Elasticsearch KMS Key Inaccessible failed over last 1 minute"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+  tags                = var.tags
 
   dimensions = {
     DomainName = var.domain_name

--- a/alarms.tf
+++ b/alarms.tf
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
 resource "aws_cloudwatch_metric_alarm" "insufficient_available_nodes" {
   count               = var.min_available_nodes > 0 ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-InsufficientAvailableNodes${var.alarm_name_postfix}"
-  comparison_operator = "LessThanOrEqualToThreshold"
+  comparison_operator = "LessThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "Nodes"
   namespace           = "AWS/ES"

--- a/alarms.tf
+++ b/alarms.tf
@@ -98,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "insufficient_available_nodes" {
-  count               = var.monitor_insufficient_available_nodes ? 1 : 0
+  count               = var.min_available_nodes > 0 ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-InsufficientAvailableNodes${var.alarm_name_postfix}"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/examples/all-alarms/main.tf
+++ b/examples/all-alarms/main.tf
@@ -31,7 +31,7 @@ module "es_alarms" {
   # You should always specify how big your ES cluster's disk size is.  Using this calculation of (size-in-gb * instance count * GB-to-MB * 20%) because 20% is the best-practice for low disk, per AWS's recommendations
   free_storage_space_threshold = var.elasticsearch_disk_size * var.elasticsearch_instance_count * 1024 * 0.20
   # Use this if using KMS on your ElasticSearch
-  monitor_kms_functioning = true
+  monitor_kms = true
   # Use these to monitor how many nodes are available and that they are all functional
   min_available_nodes = var.elasticsearch_instance_count
   # Use this to monitor high CPU on your masters (if using masters)

--- a/examples/all-alarms/main.tf
+++ b/examples/all-alarms/main.tf
@@ -1,0 +1,45 @@
+### For connecting and provisioning
+variable "region" {
+  default = "us-west-2"
+}
+provider "aws" {
+  region = var.region
+  # Make it faster by skipping something
+  skip_get_ec2_platforms      = true
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+# This specifies the disk size of each node in your ES cluster (created elsewhere)
+variable "elasticsearch_disk_size" {
+  default = 20
+}
+
+# This specifies number of nodes in your ES cluster (created elsewhere)
+variable "elasticsearch_instance_count" {
+  default = 2
+}
+
+
+module "es_alarms" {
+  source              = "../../"
+  domain_name         = "example"
+  sns_topic           = "elasticsearch-threshold-alerts"
+  sns_topic_prefix    = "prod-"
+  # You should always specify how big your ES cluster's disk size is.  Using this calculation of (size-in-gb * instance count * GB-to-MB * 20%) because 20% is the best-practice for low disk, per AWS's recommendations
+  free_storage_space_threshold = var.elasticsearch_disk_size * var.elasticsearch_instance_count * 1024 * 0.20
+  # Use this if using KMS on your ElasticSearch
+  monitor_kms_functioning = true
+  # Use these to monitor how many nodes are available and that they are all functional
+  min_available_nodes = var.elasticsearch_instance_count
+  # Use this to monitor high CPU on your masters (if using masters)
+  monitor_master_cpu_utilization_too_high = true
+  # Use this to monitor high memory on your masters (if using masters)
+  monitor_master_jvm_memory_pressure_too_high = true
+}
+
+output "es_alarms_sns_topic_arn" {
+  value = module.es_alarms.sns_topic_arn
+}

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,13 @@ data "aws_caller_identity" "default" {}
 resource "aws_sns_topic" "default_prefix" {
   count       = var.sns_topic == "" && var.create_sns_topic == true ? 1 : 0
   name_prefix = "${var.sns_topic_prefix}elasticsearch-threshold-alerts${var.sns_topic_postfix}"
+  tags        = var.tags
 }
 
 resource "aws_sns_topic" "default" {
   count = var.sns_topic != "" && var.create_sns_topic == true ? 1 : 0
   name  = "${var.sns_topic_prefix}${var.sns_topic}${var.sns_topic_postfix}"
+  tags  = var.tags
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -63,12 +63,6 @@ variable "monitor_cluster_index_writes_blocked" {
   default     = true
 }
 
-variable "monitor_insufficient_available_nodes" {
-  description = "Enable monitoring insufficient available nodes"
-  type        = bool
-  default     = false
-}
-
 variable "monitor_automated_snapshot_failure" {
   description = "Enable monitoring of automated snapshot failure"
   type        = bool
@@ -85,6 +79,12 @@ variable "monitor_jvm_memory_pressure_too_high" {
   description = "Enable monitoring of JVM memory pressure is too high"
   type        = bool
   default     = true
+}
+
+variable "monitor_kms" {
+  description = "Enable monitoring of KMS-related metrics.  Only enable this when using KMS with ElasticSearch"
+  type        = bool
+  default     = false
 }
 
 variable "monitor_master_cpu_utilization_too_high" {
@@ -106,9 +106,9 @@ variable "free_storage_space_threshold" {
 }
 
 variable "min_available_nodes" {
-  description = "The minimum available (reachable) nodes to have"
+  description = "The minimum available (reachable) nodes to have, set to non-zero to enable"
   type        = number
-  default     = 1
+  default     = 0
 }
 
 variable "cpu_utilization_threshold" {
@@ -141,4 +141,22 @@ variable "master_jvm_memory_pressure_threshold" {
   default     = 80 # default same as `jvm_memory_pressure_threshold` in Percentage
 
 
+}
+
+variable "alarm_cluster_status_is_yellow_periods" {
+  description = "The number of periods to alert that cluster status is yellow.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
+}
+
+variable "alarm_free_storage_space_too_low_periods" {
+  description = "The number of periods to alert that cluster free storage space is too low.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
Added the following features:
* Adding KMS-related alarms from the [recommended Elasticsearch Cloudwatch Alarms page](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/cloudwatch-alarms.html)
* Making this module support tagging of resources created
* Making some (normally) noisy alarms allow customizing their period to make them a bit quieter
* Cleaned up the README, added references to AWS's recommended alarms, updated to add new features
* Removed unnecessary `monitor_insufficient_available_nodes`, in favor of enabling this automatically if the number of nodes are specified, altered the default to be 0.
* Fixed a bug in the min available nodes to be < and not <=

Please do a release after this merge so everyone can leverage it.  ;)  Thanks!