### PR TITLE
remove backend.tf

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,3 +1,0 @@
-terraform {
-  backend "s3" {}
-}


### PR DESCRIPTION
in terraform 1.0.0 the `backend.tf` file results in

```bash
│ Warning: Backend configuration ignored
│
│   on .terraform/modules/es_cloudwatch_alarms/backend.tf line 2, in terraform:
│    2:   backend "s3" {}
│
│ Any selected backend applies to the entire configuration, so Terraform expects provider configurations only in the root module.
│
│ This is a warning rather than an error because it's sometimes convenient to temporarily call a root module as a child module for testing purposes, but this backend configuration block will have no effect.
```

on every plan/apply which is not desirable.