### PR TITLE
Fix #11, make create_sns_topic use consistent

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,13 @@ data "aws_caller_identity" "default" {}
 
 # Make a topic
 resource "aws_sns_topic" "default_prefix" {
-  count       = var.sns_topic == "" && var.create_sns_topic == true ? 1 : 0
+  count       = var.create_sns_topic == true ? 1 : 0
   name_prefix = "${var.sns_topic_prefix}elasticsearch-threshold-alerts${var.sns_topic_postfix}"
   tags        = var.tags
 }
 
 resource "aws_sns_topic" "default" {
-  count = var.sns_topic != "" && var.create_sns_topic == true ? 1 : 0
+  count = var.create_sns_topic == true ? 1 : 0
   name  = "${var.sns_topic_prefix}${var.sns_topic}${var.sns_topic_postfix}"
   tags  = var.tags
 }


### PR DESCRIPTION
Currently running a plan or apply using this module when the SNS topic hasnt been created but you want to create it outside of this module will fail.

```bash
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/es_cloudwatch_alarms/main.tf line 11, in resource "aws_sns_topic" "default":
│   11:   count = var.sns_topic != "" && var.create_sns_topic == true ? 1 : 0
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the
│ resources that the count depends on.
```

This is because `var.sns_topic` is a pointer to a yet-to-be-determined string that depends on the creation of the sns topic completing. Half of the places `create_sns_topic` was used had the empty string check and the other half didnt, so I removed it which allows this module to be planned/applied at the same time as an SNS topic, and it makes internal usage of `create_sns_topic` consistent.