### PR TITLE
Feature: Allowing customization of all evaluation periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,17 @@ module "es_alarms" {
 |-----------------------------------------------|-------------|:----:|:-------:|:--------:|
 | `domain_name`                                 | The Elasticserach domain name you want to monitor. | string | - | yes |
 | `cluster_type`                                | The type of cluster, single or multi-node | string | `"single"` | no |
-| `alarm_cluster_status_is_yellow_periods`      | The number of periods before triggering the cluster status is yellow, raise this if desired to make less noisy | number | `1` | no |
-| `alarm_free_storage_space_too_low_periods`    | The number of periods before triggering the disk space is low, raise this if desired to make less noisy | number | `1` | no |
+| `monitor_cluster_status_is_red_periods`      | The number of periods to alert that cluster status is red, raise this to be less noisy | number | `1` | no |
+| `alarm_cluster_status_is_yellow_periods`      | The number of periods before triggering the cluster status is yellow, raise this to be less noisy | number | `1` | no |
+| `alarm_free_storage_space_too_low_periods`    | The number of periods before triggering the disk space is low, raise this to be less noisy | number | `1` | no |
+| `monitor_cluster_index_writes_blocked_periods`    | The number of periods to alert that cluster index writes are blocked, raise this if desired to make less noisy | number | `1` | no |
+| `monitor_min_available_nodes_periods`    | The number of periods to alert that minimum number of available nodes dropped below a threshold, raise this if desired to make less noisy | number | `1` | no |
+| `monitor_automated_snapshot_failure_periods`    | The number of periods to alert that automatic snapshots failed, raise this if desired to make less noisy | number | `1` | no |
+| `monitor_cpu_utilization_too_high_periods`    | The number of periods to alert that CPU usage is too high, raise this if desired to make less noisy | number | `3` | no |
+| `monitor_jvm_memory_pressure_too_high_periods`    | The number of periods which it must be in the alarmed state to alert, raise this if desired to make less noisy | number | `1` | no |
+| `monitor_master_cpu_utilization_too_high_periods`    | The number of periods to alert that masters CPU usage is too high, raise this if desired to make less noisy | number | `3` | no |
+| `monitor_master_jvm_memory_pressure_too_high_periods`    | The number of periods which it must be in the alarmed state to alert, raise this if desired to make less noisy | number | `1` | no |
+| `monitor_kms_periods`    | The number of periods to alert that kms has failed, raise this if desired to make less noisy | number | `1` | no |
 | `alarm_name_postfix`                          | Alarm name postfix | string | `""` | no |
 | `alarm_name_prefix`                           | Alarm name prefix | string | `""` | no |
 | `cpu_utilization_threshold`                   | The maximum percentage of CPU utilization | string | `80` | no |

--- a/alarms.tf
+++ b/alarms.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_is_red" {
   count               = var.monitor_cluster_status_is_red ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterStatusIsRed${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_cluster_status_is_red_periods
   metric_name         = "ClusterStatus.red"
   namespace           = "AWS/ES"
   period              = var.monitor_cluster_status_is_red_period
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
   count               = var.monitor_cluster_index_writes_blocked ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterIndexWritesBlocked${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_cluster_index_writes_blocked_periods
   metric_name         = "ClusterIndexWritesBlocked"
   namespace           = "AWS/ES"
   period              = var.monitor_cluster_index_writes_blocked_period
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "insufficient_available_nodes" {
   count               = var.min_available_nodes > 0 ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-InsufficientAvailableNodes${var.alarm_name_postfix}"
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_min_available_nodes_periods
   metric_name         = "Nodes"
   namespace           = "AWS/ES"
   period              = var.monitor_min_available_nodes_period
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "automated_snapshot_failure" {
   count               = var.monitor_automated_snapshot_failure ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-AutomatedSnapshotFailure${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_automated_snapshot_failure_periods
   metric_name         = "AutomatedSnapshotFailure"
   namespace           = "AWS/ES"
   period              = var.monitor_automated_snapshot_failure_period
@@ -145,7 +145,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   count               = var.monitor_cpu_utilization_too_high ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-CPUUtilizationTooHigh${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
+  evaluation_periods  = var.monitor_cpu_utilization_too_high_periods
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ES"
   period              = var.monitor_cpu_utilization_too_high_period
@@ -166,7 +166,7 @@ resource "aws_cloudwatch_metric_alarm" "jvm_memory_pressure_too_high" {
   count               = var.monitor_jvm_memory_pressure_too_high ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-JVMMemoryPressure${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_jvm_memory_pressure_too_high_periods
   metric_name         = "JVMMemoryPressure"
   namespace           = "AWS/ES"
   period              = var.monitor_jvm_memory_pressure_too_high_period
@@ -187,7 +187,7 @@ resource "aws_cloudwatch_metric_alarm" "master_cpu_utilization_too_high" {
   count               = var.monitor_master_cpu_utilization_too_high ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-MasterCPUUtilizationTooHigh${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
+  evaluation_periods  = var.monitor_master_cpu_utilization_too_high_periods
   metric_name         = "MasterCPUUtilization"
   namespace           = "AWS/ES"
   period              = var.monitor_master_cpu_utilization_too_high_period
@@ -208,7 +208,7 @@ resource "aws_cloudwatch_metric_alarm" "master_jvm_memory_pressure_too_high" {
   count               = var.monitor_master_jvm_memory_pressure_too_high ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-MasterJVMMemoryPressure${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_master_jvm_memory_pressure_too_high_periods
   metric_name         = "MasterJVMMemoryPressure"
   namespace           = "AWS/ES"
   period              = var.monitor_master_jvm_memory_pressure_too_high_period
@@ -229,7 +229,7 @@ resource "aws_cloudwatch_metric_alarm" "kms_key_error" {
   count               = var.monitor_kms ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-KMSKeyError${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_kms_periods
   metric_name         = "KMSKeyError"
   namespace           = "AWS/ES"
   period              = var.monitor_kms_period
@@ -251,7 +251,7 @@ resource "aws_cloudwatch_metric_alarm" "kms_key_inaccessible" {
   count               = var.monitor_kms ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-KMSKeyInaccessible${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = var.monitor_kms_periods
   metric_name         = "KMSKeyInaccessible"
   namespace           = "AWS/ES"
   period              = var.monitor_kms_period

--- a/alarms.tf
+++ b/alarms.tf
@@ -14,6 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_is_red" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterStatusIsRed${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_cluster_status_is_red_periods
+  datapoints_to_alarm = var.monitor_cluster_status_is_red_periods
   metric_name         = "ClusterStatus.red"
   namespace           = "AWS/ES"
   period              = var.monitor_cluster_status_is_red_period
@@ -36,6 +37,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_is_yellow" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterStatusIsYellow${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.alarm_cluster_status_is_yellow_periods
+  datapoints_to_alarm = var.alarm_cluster_status_is_yellow_periods
   metric_name         = "ClusterStatus.yellow"
   namespace           = "AWS/ES"
   period              = var.monitor_cluster_status_is_yellow_period
@@ -58,6 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-FreeStorageSpaceTooLow${var.alarm_name_postfix}"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = var.alarm_free_storage_space_too_low_periods
+  datapoints_to_alarm = var.alarm_free_storage_space_too_low_periods
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/ES"
   period              = var.monitor_free_storage_space_too_low_period
@@ -80,6 +83,7 @@ resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterIndexWritesBlocked${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_cluster_index_writes_blocked_periods
+  datapoints_to_alarm = var.monitor_cluster_index_writes_blocked_periods
   metric_name         = "ClusterIndexWritesBlocked"
   namespace           = "AWS/ES"
   period              = var.monitor_cluster_index_writes_blocked_period
@@ -102,6 +106,7 @@ resource "aws_cloudwatch_metric_alarm" "insufficient_available_nodes" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-InsufficientAvailableNodes${var.alarm_name_postfix}"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.monitor_min_available_nodes_periods
+  datapoints_to_alarm = var.monitor_min_available_nodes_periods
   metric_name         = "Nodes"
   namespace           = "AWS/ES"
   period              = var.monitor_min_available_nodes_period
@@ -124,6 +129,7 @@ resource "aws_cloudwatch_metric_alarm" "automated_snapshot_failure" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-AutomatedSnapshotFailure${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_automated_snapshot_failure_periods
+  datapoints_to_alarm = var.monitor_automated_snapshot_failure_periods
   metric_name         = "AutomatedSnapshotFailure"
   namespace           = "AWS/ES"
   period              = var.monitor_automated_snapshot_failure_period
@@ -146,6 +152,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-CPUUtilizationTooHigh${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_cpu_utilization_too_high_periods
+  datapoints_to_alarm = var.monitor_cpu_utilization_too_high_periods
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ES"
   period              = var.monitor_cpu_utilization_too_high_period
@@ -167,6 +174,7 @@ resource "aws_cloudwatch_metric_alarm" "jvm_memory_pressure_too_high" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-JVMMemoryPressure${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_jvm_memory_pressure_too_high_periods
+  datapoints_to_alarm = var.monitor_jvm_memory_pressure_too_high_periods
   metric_name         = "JVMMemoryPressure"
   namespace           = "AWS/ES"
   period              = var.monitor_jvm_memory_pressure_too_high_period
@@ -188,6 +196,7 @@ resource "aws_cloudwatch_metric_alarm" "master_cpu_utilization_too_high" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-MasterCPUUtilizationTooHigh${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_master_cpu_utilization_too_high_periods
+  datapoints_to_alarm = var.monitor_master_cpu_utilization_too_high_periods
   metric_name         = "MasterCPUUtilization"
   namespace           = "AWS/ES"
   period              = var.monitor_master_cpu_utilization_too_high_period
@@ -209,6 +218,7 @@ resource "aws_cloudwatch_metric_alarm" "master_jvm_memory_pressure_too_high" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-MasterJVMMemoryPressure${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_master_jvm_memory_pressure_too_high_periods
+  datapoints_to_alarm = var.monitor_master_jvm_memory_pressure_too_high_periods
   metric_name         = "MasterJVMMemoryPressure"
   namespace           = "AWS/ES"
   period              = var.monitor_master_jvm_memory_pressure_too_high_period
@@ -230,6 +240,7 @@ resource "aws_cloudwatch_metric_alarm" "kms_key_error" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-KMSKeyError${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_kms_periods
+  datapoints_to_alarm = var.monitor_kms_periods
   metric_name         = "KMSKeyError"
   namespace           = "AWS/ES"
   period              = var.monitor_kms_period
@@ -252,6 +263,7 @@ resource "aws_cloudwatch_metric_alarm" "kms_key_inaccessible" {
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-KMSKeyInaccessible${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = var.monitor_kms_periods
+  datapoints_to_alarm = var.monitor_kms_periods
   metric_name         = "KMSKeyInaccessible"
   namespace           = "AWS/ES"
   period              = var.monitor_kms_period

--- a/variables.tf
+++ b/variables.tf
@@ -236,34 +236,28 @@ variable "master_jvm_memory_pressure_threshold" {
 ########################################
 # Evaluation periods for alarms
 ########################################
-variable "alarm_cluster_status_is_yellow_periods" {
-  description = "The number of periods to alert that cluster status is yellow.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
-  type        = number
-  default     = 1
-}
-
 variable "monitor_cluster_status_is_red_periods" {
   description = "The number of periods to alert that cluster status is red.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
   type        = number
   default     = 1
 }
 
-variable "monitor_cpu_utilization_too_high_periods" {
-  description = "The number of periods to alert that CPU usage is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
+variable "alarm_cluster_status_is_yellow_periods" {
+  description = "The number of periods to alert that cluster status is yellow.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
   type        = number
-  default     = 3
+  default     = 1
 }
 
-variable "monitor_master_cpu_utilization_too_high_periods" {
-  description = "The number of periods to alert that masters CPU usage is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
+variable "alarm_free_storage_space_too_low_periods" {
+  description = "The number of periods to alert that cluster free storage space is too low.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
   type        = number
-  default     = 3
+  default     = 1
 }
 
-variable "monitor_master_er_cpu_utilization_too_high_ds" {
-  description = "The number of periods to alert that JVM memory pressure is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
+variable "monitor_cluster_index_writes_blocked_periods" {
+  description = "The number of periods to alert that cluster index writes are blocked.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "monitor_min_available_nodes_periods" {
@@ -278,10 +272,10 @@ variable "monitor_automated_snapshot_failure_periods" {
   default     = 1
 }
 
-variable "monitor_cluster_index_writes_blocked_periods" {
-  description = "The number of periods to alert that cluster index writes are blocked.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+variable "monitor_cpu_utilization_too_high_periods" {
+  description = "The number of periods to alert that CPU usage is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
   type        = number
-  default     = 1
+  default     = 3
 }
 
 variable "monitor_jvm_memory_pressure_too_high_periods" {
@@ -290,14 +284,14 @@ variable "monitor_jvm_memory_pressure_too_high_periods" {
   default     = 1
 }
 
-variable "monitor_master_jvm_memory_pressure_too_high_periods" {
-  description = "The number of periods which it must be in the alarmed state to alert"
+variable "monitor_master_cpu_utilization_too_high_periods" {
+  description = "The number of periods to alert that masters CPU usage is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
   type        = number
-  default     = 1
+  default     = 3
 }
 
-variable "alarm_free_storage_space_too_low_periods" {
-  description = "The number of periods to alert that cluster free storage space is too low.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+variable "monitor_master_jvm_memory_pressure_too_high_periods" {
+  description = "The number of periods which it must be in the alarmed state to alert"
   type        = number
   default     = 1
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "domain_name" {
-  description = "The Elasticserach domain name you want to monitor."
+  description = "The Elasticsearch domain name you want to monitor"
   type        = string
 }
 
 variable "cluster_type" {
-  description = "The type of cluster, single or multi-node"
+  description = "The type of cluster, single or multi-node.  Used in the free_storage_space_too_low alert to calculate free storage space properly"
   type        = string
   default     = "single"
   validation {
@@ -13,6 +13,28 @@ variable "cluster_type" {
   }
 }
 
+variable "alarm_name_prefix" {
+  description = "Alarm name prefix, used in the naming of alarms created"
+  type        = string
+  default     = ""
+}
+
+variable "alarm_name_postfix" {
+  description = "Alarm name suffix, used in the naming of alarms created"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+
+########################################
+# SNS-Related Variables
+########################################
 variable "create_sns_topic" {
   description = "If you don't want to create the SNS topic, set this to false.  It will use the sns_topic value directly"
   type        = bool
@@ -25,30 +47,22 @@ variable "sns_topic" {
   default     = ""
 }
 
-variable "alarm_name_prefix" {
-  description = "Alarm name prefix"
-  type        = string
-  default     = ""
-}
-
-variable "alarm_name_postfix" {
-  description = "Alarm name postfix"
-  type        = string
-  default     = ""
-}
-
 variable "sns_topic_prefix" {
-  description = "SNS topic prefix"
+  description = "SNS topic prefix, only used if you're creating an SNS topic"
   type        = string
   default     = ""
 }
 
 variable "sns_topic_postfix" {
-  description = "SNS topic postfix"
+  description = "SNS topic suffix, only used if you're creating an SNS topic"
   type        = string
   default     = ""
 }
 
+
+########################################
+# Boolean flagging to disable specific alarms not interested in using
+########################################
 variable "monitor_cluster_status_is_red" {
   description = "Enable monitoring of cluster status is in red"
   type        = bool
@@ -109,72 +123,79 @@ variable "monitor_master_jvm_memory_pressure_too_high" {
   default     = false
 }
 
+########################################
+# Evaluation period time length (in seconds) for alarms
+########################################
 variable "monitor_min_available_nodes_period" {
   description = "The period of the minimum available nodes should the statistics be applied in seconds"
-  type        = string
-  default     = "86400"
+  type        = number
+  default     = 86400
 }
 
 variable "monitor_cluster_status_is_red_period" {
   description = "The period of the cluster status is in red should the statistics be applied in seconds"
-  type        = string
-  default     = "60"
+  type        = number
+  default     = 60
 }
 
 variable "monitor_cluster_status_is_yellow_period" {
   description = "The period of the cluster status is in yellow should the statistics be applied in seconds"
-  type        = string
-  default     = "60"
+  type        = number
+  default     = 60
 }
 
 variable "monitor_free_storage_space_too_low_period" {
   description = "The period of the cluster average free storage is too low should the statistics be applied in seconds"
-  type        = string
-  default     = "60"
+  type        = number
+  default     = 60
 }
 
 variable "monitor_cluster_index_writes_blocked_period" {
   description = "The period of the cluster index writes being blocked should the statistics be applied in seconds"
-  type        = string
-  default     = "300"
+  type        = number
+  default     = 300
 }
 
 variable "monitor_automated_snapshot_failure_period" {
   description = "The period of the automated snapshot failure should the statistics be applied in seconds"
-  type        = string
-  default     = "60"
+  type        = number
+  default     = 60
 }
 
 variable "monitor_cpu_utilization_too_high_period" {
   description = "The period of the CPU utilization is too high should the statistics be applied in seconds"
-  type        = string
-  default     = "900"
+  type        = number
+  default     = 900
 }
 
 variable "monitor_jvm_memory_pressure_too_high_period" {
   description = "The period of the JVM memory pressure is too high should the statistics be applied in seconds"
-  type        = string
-  default     = "900"
+  type        = number
+  default     = 900
 }
 
 variable "monitor_kms_period" {
   description = "The period of the KMS-related metrics should the statistics be applied in seconds"
-  type        = string
-  default     = "60"
+  type        = number
+  default     = 60
 }
 
 variable "monitor_master_cpu_utilization_too_high_period" {
   description = "The period of the CPU utilization of master nodes are too high should the statistics be applied in seconds"
-  type        = string
-  default     = "900"
+  type        = number
+  default     = 900
 }
 
 variable "monitor_master_jvm_memory_pressure_too_high_period" {
   description = "The period of the JVM memory pressure of master nodes are too high should the statistics be applied in seconds"
-  type        = string
-  default     = "900"
+  type        = number
+  default     = 900
 }
 
+
+########################################
+# Alarm thresholds
+########################################
 variable "free_storage_space_threshold" {
   description = "The minimum amount of available storage space in MegaByte."
   type        = number
@@ -190,37 +211,87 @@ variable "min_available_nodes" {
 variable "cpu_utilization_threshold" {
   description = "The maximum percentage of CPU utilization"
   type        = number
-  default     = 80
-
-  # 80 percent in Percentage
+  default     = 80   # 80 percent in Percentage
 }
 
 variable "jvm_memory_pressure_threshold" {
   description = "The maximum percentage of the Java heap used for all data nodes in the cluster"
   type        = number
-  default     = 80
-
-  # 80 percent in Percentage
+  default     = 80   # 80 percent in Percentage
 }
 
 variable "master_cpu_utilization_threshold" {
   description = "The maximum percentage of CPU utilization of master nodes"
   type        = number
-  default     = 80 # default same as `cpu_utilization_threshold` in Percentage
-
-
+  default     = 80   # default same as `cpu_utilization_threshold` in Percentage
 }
 
 variable "master_jvm_memory_pressure_threshold" {
   description = "The maximum percentage of the Java heap used for master nodes in the cluster"
   type        = number
-  default     = 80 # default same as `jvm_memory_pressure_threshold` in Percentage
-
-
+  default     = 80   # default same as `jvm_memory_pressure_threshold` in Percentage
 }
 
+
+########################################
+# Evaluation periods for alarms
+########################################
 variable "alarm_cluster_status_is_yellow_periods" {
   description = "The number of periods to alert that cluster status is yellow.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
+}
+
+variable "monitor_cluster_status_is_red_periods" {
+  description = "The number of periods to alert that cluster status is red.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
+}
+
+variable "monitor_cpu_utilization_too_high_periods" {
+  description = "The number of periods to alert that CPU usage is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 3
+}
+
+variable "monitor_master_cpu_utilization_too_high_periods" {
+  description = "The number of periods to alert that masters CPU usage is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 3
+}
+
+variable "monitor_master_er_cpu_utilization_too_high_ds" {
+  description = "The number of periods to alert that JVM memory pressure is too high.  Default: 3, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 3
+}
+
+variable "monitor_min_available_nodes_periods" {
+  description = "The number of periods to alert that minimum number of available nodes dropped below a threshold.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
+}
+
+variable "monitor_automated_snapshot_failure_periods" {
+  description = "The number of periods to alert that automatic snapshots failed.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
+}
+
+variable "monitor_cluster_index_writes_blocked_periods" {
+  description = "The number of periods to alert that cluster index writes are blocked.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
+}
+
+variable "monitor_jvm_memory_pressure_too_high_periods" {
+  description = "The number of periods which it must be in the alarmed state to alert"
+  type        = number
+  default     = 1
+}
+
+variable "monitor_master_jvm_memory_pressure_too_high_periods" {
+  description = "The number of periods which it must be in the alarmed state to alert"
   type        = number
   default     = 1
 }
@@ -231,8 +302,8 @@ variable "alarm_free_storage_space_too_low_periods" {
   default     = 1
 }
 
-variable "tags" {
-  description = "A map of tags to add to all resources"
-  type        = map(string)
-  default     = {}
+variable "monitor_kms_periods" {
+  description = "The number of periods to alert that kms has failed.  Default: 1, raise this to be less noisy, as this can occur often for only 1 period"
+  type        = number
+  default     = 1
 }

--- a/variables.tf
+++ b/variables.tf
@@ -211,25 +211,25 @@ variable "min_available_nodes" {
 variable "cpu_utilization_threshold" {
   description = "The maximum percentage of CPU utilization"
   type        = number
-  default     = 80   # 80 percent in Percentage
+  default     = 80 # 80 percent in Percentage
 }
 
 variable "jvm_memory_pressure_threshold" {
   description = "The maximum percentage of the Java heap used for all data nodes in the cluster"
   type        = number
-  default     = 80   # 80 percent in Percentage
+  default     = 80 # 80 percent in Percentage
 }
 
 variable "master_cpu_utilization_threshold" {
   description = "The maximum percentage of CPU utilization of master nodes"
   type        = number
-  default     = 80   # default same as `cpu_utilization_threshold` in Percentage
+  default     = 80 # default same as `cpu_utilization_threshold` in Percentage
 }
 
 variable "master_jvm_memory_pressure_threshold" {
   description = "The maximum percentage of the Java heap used for master nodes in the cluster"
   type        = number
-  default     = 80   # default same as `jvm_memory_pressure_threshold` in Percentage
+  default     = 80 # default same as `jvm_memory_pressure_threshold` in Percentage
 }
 
 


### PR DESCRIPTION
To help decrease the noise of alarms, this parameter needs to be tuned.  It was previously added on 2 alarms, I just added the same naming scheme as the 2 previous alarm variables for this, but for all alarms.  Please approve/merge and release.  Safe confirmed on 3 different terraform stacks with wildly different configurations.